### PR TITLE
Replace deprecated split with preg_split

### DIFF
--- a/page.php
+++ b/page.php
@@ -25,8 +25,10 @@ if( $redirect ) {
 					( $layoutMeta['layout'] != '' || $layoutMeta['layout'] != '0' )
 				) ||
 				( isset( $layoutMeta['page_type'] ) && $layoutMeta['page_type'] == 'dynamic' )
-		)
-			$content = split( "<!--more-->", $post->post_content );
+		) {
+			// Double angle brackets are necessary for the pattern to match.
+			$content = preg_split( "<<!--more-->>", $post->post_content );
+		}
 
 		// Do slideshow stuff if this page has one and the site is in the WSU theme
 		if( wp_get_theme()->Name != 'WIP' &&

--- a/single.php
+++ b/single.php
@@ -20,8 +20,10 @@ if( $redirect ) {
 		// If a layout other than "Full Width" is selected, split the post content at the more tags
 		if( isset( $layoutMeta['layout'] ) &&
 				( $layoutMeta['layout'] != '' || $layoutMeta['layout'] != '0' )
-		)
-			$content = split( "<!--more-->", $post->post_content );
+		) {
+			// Double angle brackets are necessary for the pattern to match.
+			$content = preg_split( "<<!--more-->>", $post->post_content );
+		}
 
 		// Show the title across all columns if a two equal, three, or four column layout
 		if( isset( $layoutMeta['layout'] ) &&


### PR DESCRIPTION
`split()` was deprecated in PHP 5.3.0 and has been removed completely from PHP 7. We can use `preg_split()` as a near direct replacement.